### PR TITLE
Add templates for Dampened Labouchere FX MM

### DIFF
--- a/DampenedLabouchereFX_class.tpl
+++ b/DampenedLabouchereFX_class.tpl
@@ -1,0 +1,122 @@
+// Dampened Labouchere FX Money Management implementation
+
+double dlRound(double val, int digits) {
+   double factor = MathPow(10.0, digits);
+   return MathRound(val * factor) / factor;
+}
+
+double sqMMDampenedLabouchereFX(string symbol, ENUM_ORDER_TYPE orderType, double price, double sl,
+                                double fNormal, double fDefence, double switchDebt,
+                                double switchWR, int switchRec, double multStep, double multMax,
+                                double minLot, double initialLot, double multiplier, double sizeStep) {
+   static double sequence[];
+   static int seqLen = 0;
+   static double debt = 0.0;
+   static int streak = 0;
+   static int cycleId = 1;
+   static bool winHist[100];
+   static int winHistLen = 0;
+   static int mode = 0; // 0 = Normal, 1 = Defence
+   static int lastProcessed = -1;
+   static double cycleStartBalance = 0.0;
+
+   if(seqLen == 0) {
+      ArrayResize(sequence, 2);
+      sequence[0] = 0.0;
+      sequence[1] = initialLot;
+      seqLen = 2;
+      cycleStartBalance = AccountInfoDouble(ACCOUNT_BALANCE);
+      lastProcessed = HistoryOrdersTotal() - 1;
+   }
+
+   if(lastProcessed == -1)
+      lastProcessed = HistoryOrdersTotal() - 1;
+
+   int total = HistoryOrdersTotal();
+   for(int i = lastProcessed + 1; i < total; i++) {
+      ulong ticket = HistoryOrderGetTicket(i);
+      if(ticket == 0) continue;
+      double openP  = HistoryOrderGetDouble(ticket, ORDER_PRICE_OPEN);
+      double closeP = HistoryOrderGetDouble(ticket, ORDER_PRICE_CLOSE);
+      if(openP == closeP) { lastProcessed = i; continue; }
+      double lot    = MathAbs(HistoryOrderGetDouble(ticket, ORDER_VOLUME));
+      int    type   = (int)HistoryOrderGetInteger(ticket, ORDER_TYPE);
+      bool win      = (type == ORDER_TYPE_BUY) ? (closeP > openP) : (closeP < openP);
+
+      double betVal = dlRound(sequence[0] + sequence[seqLen-1], 2);
+      if(betVal < initialLot) betVal = initialLot;
+      double mult = (streak < 3) ? 1.0 : MathMin(1.0 + (streak - 2) * multStep, multMax);
+
+      if(!win) {
+         if(winHistLen < 100) winHist[winHistLen++] = false; else { ArrayCopy(winHist, winHist, 0, 1, 99); winHist[99] = false; }
+         double sumWins = 0.0; for(int j=0;j<winHistLen;j++) if(winHist[j]) sumWins += 1.0;
+         double wr = (winHistLen == 0) ? 0.5 : (sumWins / winHistLen);
+         if(mode == 0 && (debt / AccountInfoDouble(ACCOUNT_BALANCE) > switchDebt || wr < switchWR)) mode = 1;
+         else if(mode == 1 && (streak >= switchRec || debt / AccountInfoDouble(ACCOUNT_BALANCE) < switchDebt * 0.5)) mode = 0;
+         double currentF = (mode == 1 ? fDefence : fNormal);
+         double appendVal = MathMax(initialLot, dlRound(betVal * currentF, 2));
+         ArrayResize(sequence, seqLen + 1);
+         sequence[seqLen++] = appendVal;
+         debt = dlRound(debt + lot - appendVal * mult, 2);
+         streak = 0;
+      } else {
+         if(winHistLen < 100) winHist[winHistLen++] = true; else { ArrayCopy(winHist, winHist, 0, 1, 99); winHist[99] = true; }
+         double profit = dlRound(lot, 2);
+         if(profit >= debt) {
+            profit -= debt;
+            debt = 0.0;
+            if(seqLen <= 2) {
+               ArrayResize(sequence, 2);
+               sequence[0] = 0.0;
+               sequence[1] = initialLot;
+               seqLen = 2;
+               streak = 0;
+            } else {
+               for(int j=1;j<seqLen-1;j++) sequence[j-1] = sequence[j];
+               seqLen -= 2;
+               ArrayResize(sequence, seqLen);
+               streak++;
+            }
+         } else {
+            debt = dlRound(debt - profit, 2);
+            streak++;
+         }
+      }
+
+      double balance = AccountInfoDouble(ACCOUNT_BALANCE);
+      if(seqLen == 2 && MathAbs(sequence[0]) < 1e-9 && MathAbs(sequence[1] - initialLot) < 1e-9 && MathAbs(debt) < 1e-9 && balance >= cycleStartBalance) {
+         cycleId++;
+         ArrayResize(sequence, 2);
+         sequence[0] = 0.0;
+         sequence[1] = initialLot;
+         seqLen = 2;
+         debt = 0.0;
+         streak = 0;
+         winHistLen = 0;
+         mode = 0;
+         lastProcessed = HistoryOrdersTotal() - 1;
+         cycleStartBalance = balance;
+      }
+      lastProcessed = i;
+   }
+
+   double balance = AccountInfoDouble(ACCOUNT_BALANCE);
+   double bet = dlRound(sequence[0] + sequence[seqLen-1], 2);
+   if(bet < initialLot) bet = initialLot;
+   double mult = (streak < 3) ? 1.0 : MathMin(1.0 + (streak - 2) * multStep, multMax);
+   double lot = MathMax(minLot, dlRound(bet * mult, 2));
+
+   lot *= multiplier;
+   lot = roundDown(lot, sizeStep, 2, symbol);
+
+   double minVol = SymbolInfoDouble(symbol, SYMBOL_VOLUME_MIN);
+   double maxVol = SymbolInfoDouble(symbol, SYMBOL_VOLUME_MAX);
+   double stepVol = SymbolInfoDouble(symbol, SYMBOL_VOLUME_STEP);
+
+   if(lot < minVol && lot > 0) lot = minVol;
+   lot = MathFloor(lot / stepVol) * stepVol;
+   if(lot < minVol && lot > 0) lot = minVol;
+   if(lot > maxVol) lot = maxVol;
+
+   return lot;
+}

--- a/DampenedLabouchereFX_method.tpl
+++ b/DampenedLabouchereFX_method.tpl
@@ -1,0 +1,16 @@
+<@compress_single_line>sqMMDampenedLabouchereFX(
+            <@printSymbol block />,
+            <@printOrderType block orderType directionParamName />,
+            openPrice,
+            sl,
+            mmF_NORMAL,
+            mmF_DEFENCE,
+            mmSWITCH_DEBT,
+            mmSWITCH_WR,
+            mmSWITCH_REC,
+            mmMULT_STEP,
+            mmMULT_MAX,
+            mmMIN_LOT,
+            mmINITIAL_LOT,
+            mmMultiplier,
+            mmStep)</@compress_single_line>

--- a/DampenedLabouchereFX_variables.tpl
+++ b/DampenedLabouchereFX_variables.tpl
@@ -1,0 +1,13 @@
+input string smm = "----------- Money Management - Dampened Labouchere FX MM -----------";
+input bool UseMoneyManagement = true;
+input double mmF_NORMAL = <@printMMVariableNumber "#F_NORMAL#" />;
+input double mmF_DEFENCE = <@printMMVariableNumber "#F_DEFENCE#" />;
+input double mmSWITCH_DEBT = <@printMMVariableNumber "#SWITCH_DEBT#" />;
+input double mmSWITCH_WR = <@printMMVariableNumber "#SWITCH_WR#" />;
+input int mmSWITCH_REC = <@printMMVariableNumber "#SWITCH_REC#" />;
+input double mmMULT_STEP = <@printMMVariableNumber "#MULT_STEP#" />;
+input double mmMULT_MAX = <@printMMVariableNumber "#MULT_MAX#" />;
+input double mmMIN_LOT = <@printMMVariableNumber "#MIN_LOT#" />;
+input double mmINITIAL_LOT = <@printMMVariableNumber "#INITIAL_LOT#" />;
+input double mmMultiplier = ${orderSizeMultiplier};
+input double mmStep = ${orderSizeStep};


### PR DESCRIPTION
## Summary
- convert `DampenedLabouchereFXSnippet` into MQL5 templates
- add Freemarker variables, method call and class implementation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867ad5c9e388327a51d95c40ea8e12a