### PR TITLE
Fix order type handling for DampenedLabouchereFX snippet

### DIFF
--- a/DampenedLabouchereFXSnippet_class.tpl
+++ b/DampenedLabouchereFXSnippet_class.tpl
@@ -5,7 +5,7 @@ double dlRound(double val, int digits) {
    return MathRound(val * factor) / factor;
 }
 
-double sqMMDampenedLabouchereFX(string symbol, ENUM_ORDER_TYPE orderType, double price, double sl,
+double sqMMDampenedLabouchereFX(string symbol, int orderType, double price, double sl,
                                 double fNormal, double fDefence, double switchDebt,
                                 double switchWR, int switchRec, double multStep, double multMax,
                                 double minLot, double initialLot, double multiplier, double sizeStep) {
@@ -42,7 +42,7 @@ double sqMMDampenedLabouchereFX(string symbol, ENUM_ORDER_TYPE orderType, double
       if(openP == closeP) { lastProcessed = i; continue; }
       double lot    = MathAbs(OrderLots());
       int    type   = OrderType();
-      bool win      = (type == ORDER_TYPE_BUY) ? (closeP > openP) : (closeP < openP);
+      bool win      = (type == OP_BUY) ? (closeP > openP) : (closeP < openP);
 
       double betVal = dlRound(sequence[0] + sequence[seqLen-1], 2);
       if(betVal < initialLot) betVal = initialLot;

--- a/DampenedLabouchereFXSnippet_method.tpl
+++ b/DampenedLabouchereFXSnippet_method.tpl
@@ -1,6 +1,6 @@
 <@compress_single_line>sqMMDampenedLabouchereFX(
             <@printSymbol block />,
-            <@printOrderType block orderType directionParamName />,
+            (int)<@printOrderType block orderType directionParamName />,
             openPrice,
             sl,
             mmF_NORMAL,


### PR DESCRIPTION
## Summary
- use `int` for the `orderType` parameter
- adjust win calculation to use `OP_BUY`
- cast orderType to int in method template

## Testing
- `echo "No tests to run"`

------
https://chatgpt.com/codex/tasks/task_e_687fb8ee3af0832795525e8b5d6d5799