### PR TITLE
fix: align tpl logic with Java

### DIFF
--- a/DecompositionMonteCarloMM_class.tpl
+++ b/DecompositionMonteCarloMM_class.tpl
@@ -191,7 +191,12 @@ double sqMMDecompositionMonteCarloMM(string symbol, ENUM_ORDER_TYPE orderType, d
 
    ulong deal=DecompositionMonteCarloMM_getLastClosedDeal(actualSymbol);
    if(deal>0 && deal!=st.prevTicket) {
-      double pl=HistoryDealGetDouble(deal,DEAL_PROFIT);
+      double profit=HistoryDealGetDouble(deal,DEAL_PROFIT);
+      double vol=HistoryDealGetDouble(deal,DEAL_VOLUME);
+      double tv=SymbolInfoDouble(actualSymbol,SYMBOL_TRADE_TICK_VALUE);
+      double ts=SymbolInfoDouble(actualSymbol,SYMBOL_TRADE_TICK_SIZE);
+      double pl=0.0;
+      if(vol>0 && tv>0 && ts>0) pl=profit*ts/(tv*vol);
       st.cyclePL+=pl;
       bool isWin=(pl>0.0);
       if(debugLogs) DMC_log(true,StringFormat("Before update SEQ=%s WS=%d STOCK=%d PL=%.5f",DMC_seqToString(st.sequence),st.winStreak,st.stock,pl));


### PR DESCRIPTION
## Summary
- adjust P/L computation in MQL template to match Java logic by converting deal profit into price difference before updating cycle metrics

## Testing
- `javac DecompositionMonteCarloMM.java` *(fails: cannot find symbol MoneyManagementMethod etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a4aefe98008327976fda3d4931eeae