### PR TITLE
Fix rounding in DecompositionMonteCarloMM template

### DIFF
--- a/DecompositionMonteCarloMM_class.tpl
+++ b/DecompositionMonteCarloMM_class.tpl
@@ -182,7 +182,7 @@ double DMC_computeLotFromBM(int betUnits, int multiplier, const DecompositionMon
    double lot = (double)betUnits * (double)multiplier * st.baseLot;
 
    if (st.step > 0.0)
-      lot = MathCeil(lot / st.step) * st.step;
+      lot = MathRound(lot / st.step) * st.step;
 
    return NormalizeDouble(lot, st.decimals);
 }


### PR DESCRIPTION
## Summary
- Align lot rounding in `DMC_computeLotFromBM` with Java logic by using `MathRound` instead of `MathCeil`

## Testing
- `javac DecompositionMonteCarloMM.java` *(fails: cannot find symbol MoneyManagementMethod)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ddf21fe48327a6b14e8cefe848f4