### PR TITLE
Fix DMCMM lot computation to process new orders correctly

### DIFF
--- a/DecompositionMonteCarloMM_class.tpl
+++ b/DecompositionMonteCarloMM_class.tpl
@@ -31,8 +31,11 @@ double DMCMM_ComputeLot(string symbol, long magicNumber) {
 
     int newOrders = histTotal - DMCMM_processedOrdersCount;
     if(newOrders > 0) {
-        for(int offset = newOrders - 1; offset >= 0; offset--) {
-            int index = offset;
+        for(int offset = 0; offset < newOrders; offset++) {
+            int index = DMCMM_processedOrdersCount + offset;
+            if(index < 0 || index >= histTotal) {
+                continue;
+            }
             if(!OrderSelect(index, SELECT_BY_POS, MODE_HISTORY)) {
                 continue;
             }


### PR DESCRIPTION
## Summary
- iterate over new historical orders using the stored processed count so each trade result is consumed exactly once
- process trades in chronological order and guard against out-of-range indices before selecting history orders

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68c9a6ace94883278d94396d5cb06958